### PR TITLE
Add validation checks to track_meta

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1279,6 +1279,7 @@ name = "txmeta"
 version = "0.1.0"
 dependencies = [
  "anchor-lang",
+ "squads-mpl",
 ]
 
 [[package]]

--- a/programs/txmeta/Cargo.toml
+++ b/programs/txmeta/Cargo.toml
@@ -17,3 +17,4 @@ default = []
 
 [dependencies]
 anchor-lang = "0.25.0"
+squads-mpl = { path = "../squads-mpl", features = ["no-entrypoint"] }

--- a/programs/txmeta/src/lib.rs
+++ b/programs/txmeta/src/lib.rs
@@ -1,5 +1,5 @@
 use anchor_lang::prelude::*;
-use squads_mpl::state::Ms;
+use squads_mpl::state::{Ms, MsTransaction};
 declare_id!("SMPL5bz5ERMdweouWrXtk3jmb6FnjZkWf7pHDsE6Zwz");
 
 #[program]
@@ -24,17 +24,28 @@ pub struct Track<'info> {
 
     #[account(constraint = multisig.to_account_info().owner == &squads_mpl::ID @ ErrorCode::InvalidOwner)]
     pub multisig: Account<'info, Ms>,
+
+    #[account(constraint = transaction.to_account_info().owner == &squads_mpl::ID @ ErrorCode::InvalidOwner)]
+    pub transaction: Account<'info, MsTransaction>,
 }
 
 impl<'info> Track<'info> {
-    /// Check to make sure that the signer is a member of the supplied [squads_mpl::state::Ms] account
     fn validate(ctx: &Context<Track>) -> Result<()> {
         let multisig = &ctx.accounts.multisig;
         let signer = &ctx.accounts.member;
+        let transaction = &ctx.accounts.transaction;
 
+        // Check to make sure that the signer is a member of the supplied [squads_mpl::state::Ms] account
         match multisig.is_member(signer.key()) {
-            Some(_) => Ok(()),
-            None => Err(ErrorCode::Unauthorized.into()),
+            Some(_) => {
+                // Check to make sure the signer is the creator of the supplied [squads_mpl::state::MsTransaction] account
+                // and that the transaction comes from the supplied [squads_mpl::state::Ms] account
+                if transaction.creator == signer.key() && transaction.ms == multisig.key() {
+                    return Ok(());
+                };
+                return err!(ErrorCode::InvalidTransaction);
+            }
+            None => err!(ErrorCode::Unauthorized),
         }
     }
 }
@@ -43,6 +54,8 @@ impl<'info> Track<'info> {
 pub enum ErrorCode {
     #[msg("Signer is not a member of the specified multisig.")]
     Unauthorized,
-    #[msg("The owner of the multisig account is not the expected program.")]
+    #[msg("The owner of the account is not the expected program.")]
     InvalidOwner,
+    #[msg("The transaction is either not associated with the supplied multisig or it's creator is not the supplied signer")]
+    InvalidTransaction,
 }

--- a/programs/txmeta/src/lib.rs
+++ b/programs/txmeta/src/lib.rs
@@ -1,10 +1,12 @@
 use anchor_lang::prelude::*;
+use squads_mpl::state::Ms;
 declare_id!("SMPL5bz5ERMdweouWrXtk3jmb6FnjZkWf7pHDsE6Zwz");
 
 #[program]
 pub mod txmeta {
     use super::*;
 
+    #[access_control(Track::validate(&ctx))]
     pub fn track_meta(ctx: Context<Track>, meta: String) -> Result<()> {
         let remaining = ctx.remaining_accounts;
         remaining.iter().for_each(|account| {
@@ -16,7 +18,31 @@ pub mod txmeta {
 }
 
 #[derive(Accounts)]
-pub struct Track<'info>{
+pub struct Track<'info> {
     #[account(mut)]
     pub member: Signer<'info>,
+
+    #[account(constraint = multisig.to_account_info().owner == &squads_mpl::ID @ ErrorCode::InvalidOwner)]
+    pub multisig: Account<'info, Ms>,
+}
+
+impl<'info> Track<'info> {
+    /// Check to make sure that the signer is a member of the supplied [squads_mpl::state::Ms] account
+    fn validate(ctx: &Context<Track>) -> Result<()> {
+        let multisig = &ctx.accounts.multisig;
+        let signer = &ctx.accounts.member;
+
+        match multisig.is_member(signer.key()) {
+            Some(_) => Ok(()),
+            None => Err(ErrorCode::Unauthorized.into()),
+        }
+    }
+}
+
+#[error_code]
+pub enum ErrorCode {
+    #[msg("Signer is not a member of the specified multisig.")]
+    Unauthorized,
+    #[msg("The owner of the multisig account is not the expected program.")]
+    InvalidOwner,
 }


### PR DESCRIPTION
This PR adds some validation checks to the `track_meta` instruction in the `txmeta` program