### PR TITLE
Refresh multisig after execute instruction

### DIFF
--- a/programs/mesh/src/lib.rs
+++ b/programs/mesh/src/lib.rs
@@ -523,6 +523,8 @@ pub mod mesh {
         if ctx.accounts.instruction.instruction_index == ctx.accounts.transaction.instruction_index {
             ctx.accounts.transaction.set_executed()?;
         }
+        // reload any multisig changes
+        ctx.accounts.multisig.reload()?;
         Ok(())
     }
 


### PR DESCRIPTION
There is a bug in mesh :
- Execute transaction refreshes the multisig account after CPIng
- Execute instruction doesn't

This means that any approved instruction that is executed with `execute_instruction` and modifies `ctx.accounts.multisig` won't take effect.