### PR TITLE
simplify execute_tx re-entrancy check and remove crate dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -633,12 +633,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hex"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "805026a5d0141ffc30abb3be3173848ad46a1b1664fe632428479619a3644d77"
-
-[[package]]
 name = "hmac"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1377,7 +1371,6 @@ version = "1.3.0"
 dependencies = [
  "anchor-lang",
  "default-env",
- "hex",
  "solana-security-txt",
 ]
 

--- a/programs/squads-mpl/Cargo.toml
+++ b/programs/squads-mpl/Cargo.toml
@@ -23,5 +23,4 @@ default = []
 [dependencies]
 anchor-lang = "0.26.0"
 default-env = "0.1.1"
-hex = "0.3.1"
 solana-security-txt = "1.0.1"

--- a/programs/squads-mpl/src/lib.rs
+++ b/programs/squads-mpl/src/lib.rs
@@ -5,21 +5,16 @@
 
 use anchor_lang::{
     prelude::*,
-    solana_program::{
-        instruction::Instruction,
-        program::invoke_signed
-    }
+    solana_program::{instruction::Instruction, program::invoke_signed},
 };
 
-use hex::FromHex;
-
-use state::*;
-use errors::*;
 use account::*;
+use errors::*;
+use state::*;
 
-pub mod state;
 pub mod account;
 pub mod errors;
+pub mod state;
 
 #[cfg(not(feature = "no-entrypoint"))]
 use {default_env::default_env, solana_security_txt::security_txt};
@@ -257,7 +252,7 @@ pub mod squads_mpl {
 
     /// Instruction to attach an instruction to a transaction.
     /// Transactions must be in the "draft" status, and any
-    /// signer (aside from execution payer) specified in an instruction 
+    /// signer (aside from execution payer) specified in an instruction
     /// must match the authority PDA specified during the transaction creation.
     pub fn add_instruction(
         ctx: Context<AddInstruction>,
@@ -368,9 +363,9 @@ pub mod squads_mpl {
 
     /// Instruction to execute a transaction.
     /// Transaction status must be "executeReady", and the account list must match
-    /// the unique indexed accounts in the following manner: 
+    /// the unique indexed accounts in the following manner:
     /// [ix_1_account, ix_1_program_account, ix_1_remaining_account_1, ix_1_remaining_account_2, ...]
-    /// 
+    ///
     /// Refer to the README for more information on how to construct the account list.
     pub fn execute_transaction<'info>(
         ctx: Context<'_, '_, '_, 'info, ExecuteTransaction<'info>>,
@@ -473,12 +468,16 @@ pub mod squads_mpl {
                     if &ix.program_id != ctx.program_id {
                         return err!(MsError::InvalidAuthorityIndex);
                     }
-                    // Prevent recursive call on execute_transaction/instruction that could create issues
-                    let execute_transaction = Vec::from_hex("e7ad315beb184413").unwrap();
-                    let execute_instruction = Vec::from_hex("301228284b4a936e").unwrap();
-                    if Some(execute_transaction.as_slice()) == ix.data.get(0..8) ||
-                        Some(execute_instruction.as_slice()) == ix.data.get(0..8) {
-                        return err!(MsError::InvalidAuthorityIndex);
+                    if let Some(discriminator) = ix.data.get(0..8) {
+                        // Prevent recursive call on execute_transaction/instruction that could create issues
+                        let execute_transaction = [0xe7, 0xad, 0x31, 0x5b, 0xeb, 0x18, 0x44, 0x13];
+                        let execute_instruction = [0x30, 0x12, 0x28, 0x28, 0x4b, 0x4a, 0x93, 0x6e];
+
+                        if discriminator == execute_transaction
+                            || discriminator == execute_instruction
+                        {
+                            return err!(MsError::InvalidAuthorityIndex);
+                        }
                     }
 
                     invoke_signed(&ix, &ix_account_infos, &[&ms_authority_seeds])?;
@@ -504,13 +503,13 @@ pub mod squads_mpl {
     /// this may be helpful for processing large batch transfers.
     /// This instruction can only be used for transactions with an authority
     /// index of 1 or greater.
-    /// 
+    ///
     /// NOTE - do not use this instruction if there is not total clarity around
     /// potential side effects, as this instruction implies that the approved
     /// transaction will be executed partially, and potentially spread out over
     /// a period of time. This could introduce problems with state and failed
     /// transactions. For example: a program invoked in one of these instructions
-    /// may be upgraded between executions and potentially leave one of the 
+    /// may be upgraded between executions and potentially leave one of the
     /// necessary accounts in an invalid state.
     pub fn execute_instruction<'info>(
         ctx: Context<'_, '_, '_, 'info, ExecuteInstruction<'info>>,


### PR DESCRIPTION
Same check but not allocating a vec, not converting from hex to array, single get. Finally, i feel this is more readable.

Note: Let me know if i need to revert whitespace changes and minor rust formatting