### PR TITLE
Remove dead links

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,6 @@ Technical information about SMPL [can be found in the program README.md](https:/
   * Squads V3 on-chain program: [SMPLecH534NA9acpos4G6x7uf3LWbCAwZQE9e8ZekMu](https://explorer.solana.com/address/SMPLecH534NA9acpos4G6x7uf3LWbCAwZQE9e8ZekMu)
   * Program manager: [SMPLKTQhrgo22hFCVq2VGX1KAktTWjeizkhrdB1eauK](https://explorer.solana.com/address/SMPLKTQhrgo22hFCVq2VGX1KAktTWjeizkhrdB1eauK)
 
-Both programs are [Anchor verified](https://www.apr.dev/).
-* [Squads-MPL](https://www.apr.dev/program/SMPLecH534NA9acpos4G6x7uf3LWbCAwZQE9e8ZekMu)
-* [Program Manager](https://www.apr.dev/program/SMPLKTQhrgo22hFCVq2VGX1KAktTWjeizkhrdB1eauK)
-
 # Our vision
 
 Solana needed a multisig the ecosystem could rely on, so we built one.


### PR DESCRIPTION
The apr.dev website is deprecated and links are now dead