### PR TITLE
Misprints in the text README.md

### DIFF
--- a/programs/program-manager/README.md
+++ b/programs/program-manager/README.md
@@ -4,10 +4,10 @@
 * [Instructions](#instructions)
 
 ### Overview
-The Program Manager is a simple program used to save upgrade instructions for a program managed by a Squads MPL Authority. Members of a Squad multisig can keep track of programs and upgrade buffers by invoking the various instructions provided by the program. Note, the Program Manger simply stores data about programs and their upgrades, it does not invoke any upgrade instructions on its own, but merely provides convenience for storing information about Programs that wish to be managed by a Squad multisig.
+The Program Manager is a simple program used to save upgrade instructions for a program managed by a Squads MPL Authority. Members of a Squad multisig can keep track of programs and upgrade buffers by invoking the various instructions provided by the program. Note, the Program Manager simply stores data about programs and their upgrades, it does not invoke any upgrade instructions on its own, but merely provides convenience for storing information about Programs that wish to be managed by a Squad multisig.
 
 ### Accounts
-The Program Manager has 3 types of accounts: ProgramManager, ManagedProgram, and ProgramUpgrade. In order to use the Program Manager, a member of a Squads multisig should first create a ProgramManager account derived from the Squad PDA. The ProgramManager account will keep track of Programs with the `managed_program_index`, which is used to derive the MangedProgram account address. ManagedProgram accounts simply track the address of a program being managed by the Squad, along with an upgrade_index to further track corresponding upgrade instructions. ProgramUpgrade accounts store data about a specific upgrade along with the actual upgrade instruction itself.
+The Program Manager has 3 types of accounts: ProgramManager, ManagedProgram, and ProgramUpgrade. In order to use the Program Manager, a member of a Squads multisig should first create a ProgramManager account derived from the Squad PDA. The ProgramManager account will keep track of Programs with the `managed_program_index`, which is used to derive the ManagedProgram account address. ManagedProgram accounts simply track the address of a program being managed by the Squad, along with an upgrade_index to further track corresponding upgrade instructions. ProgramUpgrade accounts store data about a specific upgrade along with the actual upgrade instruction itself.
 
 ### Instructions
 * [Create Program Manager](https://github.com/Squads-Protocol/squads-mpl/blob/main/programs/program-manager/src/lib.rs#L15)

--- a/programs/roles/README.md
+++ b/programs/roles/README.md
@@ -11,9 +11,9 @@ The Roles Program allows certain member keys to be derived that can only perform
 5. Initiate & Vote
    
 ### Invoking the Program
-The Roles Program acts a proxy on behalf of a origin key and the Squads Program - invocations first pass through the Roles Program to determine if they should be passed on to the Squads Multisig Program. If the assigned roles do not match what the origin key is trying to invoke, the the action will be rejected. The origin key is the base key which the roles and delegate keys are derived from. In the following example, we will use an origin key that is a users wallet.\
+The Roles Program acts as a proxy on behalf of an origin key and the Squads Program - invocations first pass through the Roles Program to determine if they should be passed on to the Squads Multisig Program. If the assigned roles do not match what the origin key is trying to invoke, the action will be rejected. The origin key is the base key which the roles and delegate keys are derived from. In the following example, we will use an origin key that is a users wallet.\
 Use Case:
-1. We want to create a role for this users wallet.
+1. We want to create a role for this user's wallet.
 2. The user should only be allowed to initiate/propose transactions.
 3. The user should not be allowed to vote or execute.
 


### PR DESCRIPTION
## Pull Request: Fix typos in Program Manager documentation

### Changes:
1. Fixed a typo: "Program Manger" → "Program Manager"
2. Fixed a typo: "MangedProgram" → "ManagedProgram"

### Affected files:
- `README.md` (or relevant file name)